### PR TITLE
Home Page: Display gallery load failures only when none succeed

### DIFF
--- a/ui/app/containers/HomePage/actions.js
+++ b/ui/app/containers/HomePage/actions.js
@@ -10,7 +10,7 @@ export function loadGalleries() {
   };
 }
 
-export function galleriesLoaded(galleries) {
+export function galleriesLoadingSuccess(galleries) {
   return {
     galleries,
     type: LOAD_GALLERIES_SUCCESS,

--- a/ui/app/containers/HomePage/index.jsx
+++ b/ui/app/containers/HomePage/index.jsx
@@ -17,13 +17,13 @@ import { loadGalleries } from './actions';
 import {
   makeSelectItems,
   makeSelectGalleryLoading,
-  makeSelectGalleryError,
+  makeSelectGalleryErrors,
 } from './selectors';
 import reducer from './reducer';
 import saga from './saga';
 
 export function HomePage({
-  galleryError,
+  galleryErrors,
   galleryLoading,
   items,
   onLoad,
@@ -34,7 +34,7 @@ export function HomePage({
 
   const galleryListProps = {
     loading: galleryLoading,
-    error: galleryError,
+    error: galleryErrors,
     items,
     component: GalleryListItem,
   };
@@ -65,7 +65,7 @@ export function mapDispatchToProps(dispatch) {
 const mapStateToProps = createStructuredSelector({
   items: makeSelectItems(),
   galleryLoading: makeSelectGalleryLoading(),
-  galleryError: makeSelectGalleryError(),
+  galleryErrors: makeSelectGalleryErrors(),
 });
 
 const withConnect = connect(

--- a/ui/app/containers/HomePage/reducer.js
+++ b/ui/app/containers/HomePage/reducer.js
@@ -6,10 +6,10 @@ import {
   LOAD_GALLERIES_ERROR,
 } from './constants';
 
-// The initial state of the App
+// The initial state of the HomePage
 export const initialState = {
-  galleryError: false,
-  galleryLoading: false,
+  galleryErrors: [false, false],
+  galleryLoadings: [false, false],
   galleries: {
     dropbox: [],
     local: [],
@@ -20,12 +20,12 @@ export const initialState = {
 const homeReducer = (state = initialState, action) => produce(state, (draft) => {
   switch (action.type) {
     case LOAD_GALLERIES:
-      draft.galleryError = false;
-      draft.galleryLoading = true;
+      draft.galleryLoadings = [true, true];
+      draft.galleryErrors = [false, false];
       break;
 
     case LOAD_GALLERIES_SUCCESS:
-      draft.galleryLoading = false;
+      draft.galleryLoadings[draft.galleryLoadings.indexOf(true)] = false;
       if (action.galleries && action.galleries.dropbox && action.galleries.dropbox.entries) {
         draft.galleries.dropbox = action.galleries.dropbox.entries.map(item => ({
           id: item.id,
@@ -38,8 +38,8 @@ const homeReducer = (state = initialState, action) => produce(state, (draft) => 
       break;
 
     case LOAD_GALLERIES_ERROR:
-      draft.galleryError = action.error;
-      draft.galleryLoading = false;
+      draft.galleryErrors[draft.galleryErrors.indexOf(false)] = action.error.message;
+      draft.galleryLoadings[draft.galleryLoadings.indexOf(true)] = false;
       break;
   }
 });

--- a/ui/app/containers/HomePage/saga.js
+++ b/ui/app/containers/HomePage/saga.js
@@ -8,7 +8,7 @@ import {
 } from 'redux-saga/effects';
 
 import request from '../../utils/request';
-import { galleriesLoaded, galleriesLoadingError } from './actions';
+import { galleriesLoadingSuccess, galleriesLoadingError } from './actions';
 import { LOAD_GALLERIES } from './constants';
 
 // Dropbox API v2 request/response handler
@@ -17,14 +17,18 @@ export function* getDropboxGalleries() {
     const accessToken = process.env.HISTORY_DROPBOX_ACCESS_TOKEN;
 
     if (!accessToken) {
+      const error = new ReferenceError('.env is missing HISTORY_DROPBOX_ACCESS_TOKEN');
+      console.error(error);
+      yield put(galleriesLoadingError(error));
       return;
     }
 
     const dbx = new Dropbox({ accessToken, fetch });
 
     const galleries = yield call([dbx, dbx.filesListFolder], { path: '/public' });
-    yield put(galleriesLoaded({ dropbox: galleries }));
+    yield put(galleriesLoadingSuccess({ dropbox: galleries }));
   } catch (error) {
+    console.error(error);
     yield put(galleriesLoadingError(error));
   }
 }
@@ -32,8 +36,9 @@ export function* getDropboxGalleries() {
 function* getLocalFolders() {
   try {
     const { galleries } = yield call(request, 'http://localhost:8000/gallery/list');
-    yield put(galleriesLoaded({ local: galleries.map(name => ({ name, id: `local-${name}` })) }));
+    yield put(galleriesLoadingSuccess({ local: galleries.map(name => ({ name, id: `local-${name}` })) }));
   } catch (error) {
+    console.error(error);
     yield put(galleriesLoadingError(error));
   }
 }

--- a/ui/app/containers/HomePage/selectors.js
+++ b/ui/app/containers/HomePage/selectors.js
@@ -14,17 +14,23 @@ const makeSelectItems = () => createSelector(
 
 const makeSelectGalleryLoading = () => createSelector(
   selectHome,
-  homeState => homeState.galleryLoading,
+  homeState => homeState.galleryLoadings.includes(true),
 );
 
-const makeSelectGalleryError = () => createSelector(
+const makeSelectGalleryErrors = () => createSelector(
   selectHome,
-  homeState => homeState.galleryError,
+  (homeState) => {
+    if (homeState.galleryErrors.includes(false) === true) {
+      return false;
+    }
+
+    return { message: 'All galleries failed to load' };
+  },
 );
 
 export {
   selectHome,
   makeSelectItems,
   makeSelectGalleryLoading,
-  makeSelectGalleryError,
+  makeSelectGalleryErrors,
 };

--- a/ui/app/containers/HomePage/tests/actions.test.js
+++ b/ui/app/containers/HomePage/tests/actions.test.js
@@ -7,7 +7,7 @@ import {
 
 import {
   loadGalleries,
-  galleriesLoaded,
+  galleriesLoadingSuccess,
   galleriesLoadingError,
 } from '../actions';
 
@@ -20,14 +20,14 @@ describe('Home Actions', () => {
     expect(loadGalleries()).toEqual(expectedResult);
   });
 
-  test('galleriesLoaded', () => {
+  test('galleriesLoadingSuccess', () => {
     const galleries = ['gallery'];
     const expectedResult = {
       galleries,
       type: LOAD_GALLERIES_SUCCESS,
     };
 
-    expect(galleriesLoaded(galleries)).toEqual(expectedResult);
+    expect(galleriesLoadingSuccess(galleries)).toEqual(expectedResult);
   });
 
   test('galleriesLoadingError', () => {

--- a/ui/app/containers/HomePage/tests/reducer.jest.js
+++ b/ui/app/containers/HomePage/tests/reducer.jest.js
@@ -4,7 +4,7 @@ import produce from 'immer';
 import homeReducer, { initialState } from '../reducer';
 import {
   loadGalleries,
-  galleriesLoaded,
+  galleriesLoadingSuccess,
   galleriesLoadingError,
 } from '../actions';
 
@@ -22,26 +22,26 @@ describe('homeReducer', () => {
 
   test('should handle the loadGalleries action correctly', () => {
     const expectedResult = produce(state, (draft) => {
-      draft.galleryLoading = true;
+      draft.galleryLoadings = true;
     });
 
     expect(homeReducer(state, loadGalleries())).toEqual(expectedResult);
   });
 
-  test('should handle the galleriesLoaded action correctly', () => {
+  test('should handle the galleriesLoadingSuccess action correctly', () => {
     const fixture = { entries: [{ name: 'gallery-demo', path_lower: '/public/gallery-demo' }] };
     const expectedResult = produce(state, (draft) => {
-      draft.galleryLoading = false;
+      draft.galleryLoadings = false;
       draft.contents = fixture.entries;
     });
 
-    expect(homeReducer(state, galleriesLoaded(fixture))).toEqual(expectedResult);
+    expect(homeReducer(state, galleriesLoadingSuccess(fixture))).toEqual(expectedResult);
   });
 
   test('should handle the galleriesLoadingError action correctly', () => {
     const fixture = { type: 'ReferenceError' };
     const expectedResult = produce(state, (draft) => {
-      draft.galleryError = fixture;
+      draft.galleryErrors = fixture;
     });
 
     expect(homeReducer(state, galleriesLoadingError(fixture))).toEqual(expectedResult);

--- a/ui/app/containers/HomePage/tests/selectors.jest.js
+++ b/ui/app/containers/HomePage/tests/selectors.jest.js
@@ -3,7 +3,7 @@
 import {
   selectHome,
   makeSelectGalleryLoading,
-  makeSelectGalleryError,
+  makeSelectGalleryErrors,
 } from '../selectors';
 
 describe('selectHome', () => {
@@ -19,27 +19,27 @@ describe('selectHome', () => {
 });
 
 describe('makeSelectGalleryLoading', () => {
-  const galleryLoadingSelector = makeSelectGalleryLoading();
+  const galleryLoadingsSelector = makeSelectGalleryLoading();
   test('should select the loading status', () => {
-    const galleryLoading = true;
+    const galleryLoadings = true;
     const mockedState = {
       home: {
-        galleryLoading,
+        galleryLoadings,
       },
     };
-    expect(galleryLoadingSelector(mockedState)).toEqual(galleryLoading);
+    expect(galleryLoadingsSelector(mockedState)).toEqual(galleryLoadings);
   });
 });
 
-describe('makeSelectGalleryError', () => {
-  const galleryErrorSelector = makeSelectGalleryError();
+describe('makeSelectGalleryErrors', () => {
+  const galleryErrorsSelector = makeSelectGalleryErrors();
   test('should select the error status', () => {
-    const galleryError = true;
+    const galleryErrors = true;
     const mockedState = {
       home: {
-        galleryError,
+        galleryErrors,
       },
     };
-    expect(galleryErrorSelector(mockedState)).toEqual(galleryError);
+    expect(galleryErrorsSelector(mockedState)).toEqual(galleryErrors);
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
If one of the galleries loads then display the result (e.g. Dropbox succeeds but local fails). Only display an error message when all galleries fail to load
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Untouched
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
